### PR TITLE
use "1" for dimensionless VOUnit in Table 14

### DIFF
--- a/VOUnits.tex
+++ b/VOUnits.tex
@@ -1448,7 +1448,7 @@ first appear to have rough consensus, is disturbingly heterogeneous.
     adu & \unit{} & \unit{} & \unit{} & \unit{adu} &\\\cline{1-5}
     beam & \unit{} & \unit{} & \unit{} & \unit{beam} &\\\hline
      & \unit{} & \unit{Crab} avoid use & \unit{} & \unit{} & not used \\\hline
-    No unit, dimensionless & \unit{} & blank string & \unit{-} & \unit{} & empty string \\\hline
+    No unit, dimensionless & \unit{} & blank string & \unit{-} & \unit{} & \unit{1} \\\hline
     Percent &  &  & \unit{\%} & & \unit{\%} \\\hline
     unknown & \unit{} & {\tiny\unit{UNKNOWN}} & \unit{} & \unit{} & \unit{unknown} \\\hline
 \end{tabular}


### PR DESCRIPTION
Update the VOUnits entry for "No unit, dimensionless" in Table 14
to read "1" instead of "empty string" for consistency with the modified
(at VOUnits 1.1) text in section 2.2.