### PR TITLE
Added text to discuss scale-factors in function-application.

### DIFF
--- a/VOUnits.tex
+++ b/VOUnits.tex
@@ -1731,23 +1731,6 @@ spec, but includes language which arguably permits such an
 expression.  The grammars for the FITS and OGIP syntaxes, presented
 here, do not permit a scale factor in such a position.
 
-%% Discussion from https://github.com/ivoa-std/VOUnits/issues/17
-%%
-%% Specifically (detail...): The nearest to a proscription is the FITS
-%% spec, which says that 'The final units string is the compound string,
-%% or a compound of compounds, preceded by an optional numeric
-%% multiplier...', implicitly distinguishing 'the final units string'
-%% from 'base unit strings': a narrow interpretation of this would deem
-%% the operand to log(x) to be a 'base unit string', which doesn't have
-%% this 'optional numeric multiplier' prepended). The OGIP spec largely
-%% inherits the FITS spec, but is slightly contradictory, in that it says
-%% that str1 in 'log(str1)' is 'strings conforming to the rules given in
-%% Section 2 to specify physical units.' (which could be taken to rule
-%% out permitting a scalefactor, but also says 'the numerical factor can
-%% simply be considered a basic unit string', which would seem to
-%% more-or-less explicitly permit it.
-
-
 Other ambiguities:
 \begin{itemize}
 \item The FITS specification may or may not be intended to permit

--- a/VOUnits.tex
+++ b/VOUnits.tex
@@ -911,7 +911,7 @@ as summarized in \prettyref{tab:VOUnitCombine}.
 \unit{str1**expr} & Raised to the power expr \\
 %\unit{str1\^{}expr} & Raised to the power expr \\
 %\unit{str1expr} & Raised to the power expr \\
-\unit{fn(str1)} & Function applied to a unit string\\
+\unit{fn(expr)} & Function applied to a unit string\\
 %% \unit{log(str1)} & Common Logarithm (to base 10) \\
 %% \unit{ln(str1)} & Natural Logarithm \\
 %% \unit{exp(str1)} & Exponential (e$^\mathrm{str1}$) \\
@@ -945,13 +945,19 @@ indicate that they \norm{must not} be interpreted as in this table.
 \hline
 \end{tabular}
 \end{center}
-\caption{\label{tab:functions}Functions of units.}
+\caption{\label{tab:functions}Functions of units, listed as `known'
+  for VOUnits expressions.}
 \end{table}
+
 Note that since functions such as `log' require dimensionless
 arguments, when a quantity~$x$ is (for example) represented by numbers
 labelled with units \unit{log(Hz)}, that indicates that the numbers
 are related to~$x$ by the function
-$\log\bigl(x/(\mathrm{1\,Hz})\bigr)$.
+$\log\bigl(x/(\mathrm{1\,Hz})\bigr)$.  In the VOUnits syntax, function
+operands can include a scale factor, so that if a column were
+labelled with the expression \unit{log(10**6Hz)}, the numbers in the
+column represent $\log\bigl(x/(\mathrm{10^6\,Hz})\bigr)$ (though
+representing this as \unit{log(MHz)} would be preferable.
 
 %\subsection{Quantities}
 %\label{sec:quantities}
@@ -1680,8 +1686,8 @@ the digits are \hex{30} to \hex{39}, the letters are \hex{41} to \hex{5a} and \h
 
 For the FITS units syntax, see section~4.3 of the FITS\,3
 or FITS\,4 specifications \citep{pence10,fits4}, and the
-associated tables.  Our preferred FITS grammar is in
-\prettyref{tabx:fitsgrammar}.
+associated tables.  Our preferred interpretation of the FITS grammar
+is in \prettyref{tabx:fitsgrammar}.
 
 As noted above in \prettyref{sec:fitsquote},
 the FITS specification isn't completely clear on the topic of
@@ -1718,9 +1724,33 @@ The FITS specification permits \texttt{m(2)}, to indicate the square of
 unit~`m'.  The grammar has to special-case this, in order to
 distinguish it from function application.
 
+A reasonably narrow interpretation of the FITS spec appears to rule
+out numeric scale factors in function-application (ie, expressions
+such as \unit{log(10**6Hz)}).  The OGIP spec largely inherits the FITS
+spec, but includes language which arguably permits such an
+expression.  The grammars for the FITS and OGIP syntaxes, presented
+here, do not permit a scale factor in such a position.
+
+%% Discussion from https://github.com/ivoa-std/VOUnits/issues/17
+%%
+%% Specifically (detail...): The nearest to a proscription is the FITS
+%% spec, which says that 'The final units string is the compound string,
+%% or a compound of compounds, preceded by an optional numeric
+%% multiplier...', implicitly distinguishing 'the final units string'
+%% from 'base unit strings': a narrow interpretation of this would deem
+%% the operand to log(x) to be a 'base unit string', which doesn't have
+%% this 'optional numeric multiplier' prepended). The OGIP spec largely
+%% inherits the FITS spec, but is slightly contradictory, in that it says
+%% that str1 in 'log(str1)' is 'strings conforming to the rules given in
+%% Section 2 to specify physical units.' (which could be taken to rule
+%% out permitting a scalefactor, but also says 'the numerical factor can
+%% simply be considered a basic unit string', which would seem to
+%% more-or-less explicitly permit it.
+
+
 Other ambiguities:
 \begin{itemize}
-\item The FITS specification may or may not be intended to permit 
+\item The FITS specification may or may not be intended to permit
   \texttt{10+3 /m}, but we don't.
 \item It is possible to read the FITS spec as permitting
   \texttt{m\^{}1.5}, without parentheses.  We take it to be


### PR DESCRIPTION
Addresses issue #17.

Despite the discussion in that issue, the preferred grammars (or rather, the grammars as (not) adjusted in relation to [unity issue not permit scalefactors.

Firstly, there's only ambiguous justification for including them, based on the described FITS/OGIP grammars.  Secondly, the fact that FITS permits `m(2)`, meaning `m^2`, means that function-application is nearly ambiguous anyway, and I was not able to find a way of resolving that in a straightforward way.  I think we can take that as a hint that we shouldn't be creative here.