### PR TITLE
Fix missing QUDT item name

### DIFF
--- a/VOUnits.tex
+++ b/VOUnits.tex
@@ -1430,7 +1430,8 @@ use as the toolkit behind the \textsc{casa} package).
 %USNO NOVAS
 %\violet{\footnotesize{\url{http://aa.usno.navy.mil/software/novas/novas_info.php}}}\\
 %implement the IAU 2000 recommendations.
-\item[QUDT] The QUDT unit framework~\citep{qudt} is a set of detailed
+\item[QUDT]
+The QUDT unit framework~\citep{qudt} is a set of detailed
   semantic specifications for units of measure, quantity kind,
   dimensions and data types, as used in the physical sciences.
 \end{bigdescription}


### PR DESCRIPTION
The QUDT item in appendix A.5 was missing the item name in the PDF, and all text after this section was bold in the HTML version.